### PR TITLE
Fix `Game.changeTurn`

### DIFF
--- a/src/main/kotlin/com/grupox/wololo/model/User.kt
+++ b/src/main/kotlin/com/grupox/wololo/model/User.kt
@@ -27,4 +27,15 @@ class User(val username: String, mail: String, private var password: String, val
             username = username,
             stats = stats
         )
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is User) {
+            return false
+        }
+        return id == other.id
+    }
 }


### PR DESCRIPTION
La implementación actual de `Game.changeTurn` usa `indexOf`, que a su vez usa internamente `equals`, y como actualmente no esta overrideado, hace una comparación por identidad.

Dejó de funcionar porque mongodb da instancias distintas de `User` para el mismo objeto. Hacer que el `equals` compare solamente por id no es lo mejor, pero funciona.

Agrego un poco mas a la explicación anterior, que creo que es medio pobre. Éste es el código de Game.changeTurn:
```kotlin
    private fun changeTurn() {
        // Supongamos que es un juego de dos usuarios, User(id=1) y User(id=2)
        // `turn` podría ser User(id=1) o 2, pero la instancia de user que voy a tener en turn
        // es una instancia distinta de las que tengo en `players` 
        val playersIterator = players.listIterator(players.indexOf(turn) + 1)
        // `players.indexOf(turn)` retorna siempre -1, y siempre nos quedamos con el primer valor de `players`
        turn = if(playersIterator.hasNext())
            playersIterator.next()
        else
            players.first()
        province.addGauchosToAllTownsFrom(turn)
    }
```

Avisen si no se entiende, mergeen si están de acuerdo.